### PR TITLE
Update infracost to INFRACOST_VERSION=0.10.41

### DIFF
--- a/env0/custom-image/spectral-image/Dockerfile
+++ b/env0/custom-image/spectral-image/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --virtual=build gcc make openssl-dev libffi-dev musl-dev linux-heade
     && apk del --purge build \
     && az --version
 
-ARG INFRACOST_VERSION=0.10.40
+ARG INFRACOST_VERSION=0.10.41
 # Install infracost
 RUN curl -sL https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz | tar xz  && \
 mv infracost-linux-amd64 /opt/infracost


### PR DESCRIPTION
Update to their current [latest version](https://github.com/infracost/infracost/releases) whereas we know some vulnerabilities were fixed like [go-git](https://github.com/infracost/infracost/issues/3312)

Created these:
![image](https://github.com/user-attachments/assets/8f2e04a6-6e54-488c-8e96-57e8ac35f45d)
