### PR TITLE
Match Architecture for GitHub Actions

### DIFF
--- a/env0/custom-image/spectral-image/Dockerfile
+++ b/env0/custom-image/spectral-image/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="/opt/global_python_venv/bin:${PATH}"
 
 # Define the version/tag for Wiz CLI
 ARG WIZCLI_VERSION=0.46.0
-ARG WIZCLI_ARCH=arm64
+ARG WIZCLI_ARCH=amd64
 
 # Install dependencies for GPG, SHA256 verification, and potentially wizcli's runtime
 # (libc-utils provides 'ldd' and sometimes helps with musl-libc compatibility for glibc binaries)


### PR DESCRIPTION
[We got an error in the GitHub action build process 
](https://github.com/env0/acme-demo/actions/runs/15809274889)
This error, occurring on a binary executable (/usr/local/bin/wizcli), is an indicator of an architecture mismatch when the shell tries to execute the file. It's trying to interpret the raw bytes of the binary as a shell script, and the first byte isn't valid script syntax for it.

The Problem: Architecture Conflict in GitHub Actions
Here's what's happening:

Your Dockerfile: You last provided a Dockerfile with:

Dockerfile

ARG WIZCLI_ARCH=arm64
...
RUN curl -sL -o /tmp/wizcli https://downloads.wiz.io/wizcli/${WIZCLI_VERSION}/wizcli-linux-${WIZCLI_ARCH} && \
This tells Docker to download the wizcli-linux-arm64 binary.

GitHub Actions Runner: Your workflow specifies runs-on: ubuntu-latest.

ubuntu-latest runners in GitHub Actions are typically AMD64 (x86_64) architecture, not ARM64.
The Conflict: You are attempting to download an ARM64 binary (wizcli-linux-arm64) and then execute it on an AMD64 Linux machine (the GitHub Actions runner's CPU architecture). While Docker Desktop on your Mac might be able to emulate amd64 or arm64 builds, the native execution environment of the Ubuntu-latest runner is amd64.

This causes the syntax error: unexpected "(" as the AMD64 shell tries to understand what it perceives as a foreign executable format.

